### PR TITLE
Add announcement maintenance mode

### DIFF
--- a/frontend/src/assets/scss/base.scss
+++ b/frontend/src/assets/scss/base.scss
@@ -377,12 +377,20 @@
     background-color: $danger-color !important;
   }
 
+  .bg-maintenance{
+    background-color: $maint-color !important;
+  }
+
   .bg-success .dyn-dark {
     background-color: darken($success-color, 10%) !important;
   }
 
   .bg-danger .dyn-dark {
     background-color: darken($danger-color, 10%) !important;
+  }
+
+  .bg-maintenance .dyn-dark {
+    background-color: darken($maint-color, 10%) !important;
   }
 
   @keyframes fadeInOut {

--- a/frontend/src/assets/scss/variables.scss
+++ b/frontend/src/assets/scss/variables.scss
@@ -32,6 +32,7 @@ $service-card-height: 480px;
 /*    Button Colors      */
 $success-color: #47d337;
 $danger-color: #dd3545;
+$maint-color: #006bf6;
 $primary-color: #3e9bff;
 
 /*   Footer Settings   */

--- a/frontend/src/components/Index/Group.vue
+++ b/frontend/src/components/Index/Group.vue
@@ -8,7 +8,8 @@
                   {{service.name}}
                   <MessagesIcon :messages="service.messages"/>
                 </router-link>
-                <span class="badge text-uppercase float-right" :class="{'bg-success': service.online, 'bg-danger': !service.online }">
+                <span v-if="service.maintenance_mode" class="badge float-right bg-maintenance">MAINTENANCE</span>
+                <span v-else class="badge text-uppercase float-right" :class="{'bg-success': service.online, 'bg-danger': !service.online }">
                     {{service.online ? $t('online') : $t('offline')}}
                 </span>
 

--- a/frontend/src/forms/Message.vue
+++ b/frontend/src/forms/Message.vue
@@ -54,6 +54,16 @@
             </div>
           </div>
 
+          <div class="form-group row">
+            <label for="notify_method" class="col-sm-4 col-form-label">{{ $t('maintenance_mode') }}</label>
+            <div class="col-sm-8">
+              <span @click="message.maintenance_mode = !!message.maintenance_mode" class="switch">
+                <input v-model="message.maintenance_mode" type="checkbox" class="switch" id="switch-maint">
+                <label for="switch-maint">{{ $t('maintenance_desc') }}</label>
+              </span>
+            </div>
+          </div>
+
           <div v-if="message.notify" class="form-group row">
             <label for="notify_method" class="col-sm-4 col-form-label">{{ $t('notify_method') }}</label>
             <div class="col-sm-8">

--- a/frontend/src/forms/Message.vue
+++ b/frontend/src/forms/Message.vue
@@ -54,7 +54,7 @@
             </div>
           </div>
 
-          <div class="form-group row">
+          <div v-if="message.service !== 0" class="form-group row">
             <label for="notify_method" class="col-sm-4 col-form-label">{{ $t('maintenance_mode') }}</label>
             <div class="col-sm-8">
               <span @click="message.maintenance_mode = !!message.maintenance_mode" class="switch">

--- a/frontend/src/languages/english.js
+++ b/frontend/src/languages/english.js
@@ -141,7 +141,9 @@ const english = {
     number_of_days_for_service_desc: "How many days of history show for a service.",
     show_graphs: "Show Graphs",
     show_graphs_desc: "Show graphs for services. If off, all graphs will be hidden despite their individual settings.",
-    show_graph: "Show Graph"
+    show_graph: "Show Graph",
+    maintenance_desc: "Put service in maintenance mode.",
+    maintenance_mode: "Maintenance Mode"
 }
 
 export default english

--- a/frontend/src/pages/Index.vue
+++ b/frontend/src/pages/Index.vue
@@ -23,7 +23,8 @@
                     {{service.name}}
                     <MessagesIcon :messages="service.messages"/>
                   </router-link>
-                  <span class="badge float-right" :class="{'bg-success': service.online, 'bg-danger': !service.online }">{{service.online ? "ONLINE" : "OFFLINE"}}</span>
+                  <span v-if="service.maintenance_mode" class="badge float-right bg-maintenance">MAINTENANCE</span>
+                  <span v-else class="badge float-right" :class="{'bg-success': service.online, 'bg-danger': !service.online }">{{service.online ? "ONLINE" : "OFFLINE"}}</span>
                   <GroupServiceFailures :service="service"/>
                   <IncidentsBlock :service="service"/>
               </div>

--- a/handlers/services.go
+++ b/handlers/services.go
@@ -1,6 +1,8 @@
 package handlers
 
 import (
+	"net/http"
+
 	"github.com/gorilla/mux"
 	"github.com/statping-ng/statping-ng/database"
 	"github.com/statping-ng/statping-ng/types/errors"
@@ -8,7 +10,6 @@ import (
 	"github.com/statping-ng/statping-ng/types/hits"
 	"github.com/statping-ng/statping-ng/types/services"
 	"github.com/statping-ng/statping-ng/utils"
-	"net/http"
 )
 
 type serviceOrder struct {
@@ -55,6 +56,7 @@ func apiServiceHandler(r *http.Request) interface{} {
 		return err
 	}
 	srv = srv.UpdateStats()
+	srv = srv.CheckMaintenance()
 	return *srv
 }
 

--- a/types/messages/methods.go
+++ b/types/messages/methods.go
@@ -1,0 +1,10 @@
+package messages
+
+import (
+	"github.com/statping-ng/statping-ng/utils"
+)
+
+func (m *Message) IsActive() bool {
+	curr := utils.Now()
+	return curr.Before(m.EndOn) && curr.After(m.StartOn)
+}

--- a/types/messages/struct.go
+++ b/types/messages/struct.go
@@ -1,8 +1,9 @@
 package messages
 
 import (
-	"github.com/statping-ng/statping-ng/types/null"
 	"time"
+
+	"github.com/statping-ng/statping-ng/types/null"
 )
 
 // Message is for creating Announcements, Alerts and other messages for the end users
@@ -19,4 +20,5 @@ type Message struct {
 	NotifyBeforeScale string         `gorm:"column:notify_before_scale" json:"notify_before_scale" scope:"user,admin"`
 	CreatedAt         time.Time      `gorm:"column:created_at" json:"created_at" json:"created_at"`
 	UpdatedAt         time.Time      `gorm:"column:updated_at" json:"updated_at" json:"updated_at"`
+	MaintenanceMode   null.NullBool  `gorm:"column:maintenance_mode" json:"maintenance_mode"`
 }

--- a/types/services/database.go
+++ b/types/services/database.go
@@ -2,11 +2,12 @@ package services
 
 import (
 	"fmt"
+	"sort"
+
 	"github.com/statping-ng/statping-ng/database"
 	"github.com/statping-ng/statping-ng/types/errors"
 	"github.com/statping-ng/statping-ng/types/metrics"
 	"github.com/statping-ng/statping-ng/utils"
-	"sort"
 )
 
 var (
@@ -90,6 +91,7 @@ func All() map[int64]*Service {
 func AllInOrder() []Service {
 	var services []Service
 	for _, service := range allServices {
+		service.CheckMaintenance()
 		service.UpdateStats()
 		services = append(services, *service)
 	}

--- a/types/services/methods.go
+++ b/types/services/methods.go
@@ -6,15 +6,16 @@ import (
 	"crypto/x509"
 	"encoding/hex"
 	"fmt"
+	"io/ioutil"
+	"sort"
+	"strconv"
+	"time"
+
 	"github.com/statping-ng/statping-ng/types"
 	"github.com/statping-ng/statping-ng/types/errors"
 	"github.com/statping-ng/statping-ng/types/failures"
 	"github.com/statping-ng/statping-ng/types/hits"
 	"github.com/statping-ng/statping-ng/utils"
-	"io/ioutil"
-	"sort"
-	"strconv"
-	"time"
 )
 
 const limitedFailures = 25
@@ -258,6 +259,18 @@ func (s *Service) UpdateStats() *Service {
 		Hits:     s.AllHits().Count(),
 		FirstHit: s.FirstHit().CreatedAt,
 	}
+	return s
+}
+
+func (s *Service) CheckMaintenance() *Service {
+	active := false
+	for _, msg := range s.Messages {
+		if msg.IsActive() && msg.MaintenanceMode.Bool {
+			active = true
+		}
+	}
+
+	s.MaintenanceMode = active
 	return s
 }
 

--- a/types/services/struct.go
+++ b/types/services/struct.go
@@ -51,7 +51,8 @@ type Service struct {
 	NotifyAfter         int64                 `gorm:"column:notify_after" json:"notify_after" yaml:"notify_after" scope:"user,admin"`
 	AllowNotifications  null.NullBool         `gorm:"default:true;column:allow_notifications" json:"allow_notifications" yaml:"allow_notifications" scope:"user,admin"`
 	UpdateNotify        null.NullBool         `gorm:"default:true;column:notify_all_changes" json:"notify_all_changes" yaml:"notify_all_changes" scope:"user,admin"` // This Variable is a simple copy of `core.CoreApp.UpdateNotify.Bool`
-	DownText            string                `gorm:"-" json:"-" yaml:"-"`                                                                                           // Contains the current generated Downtime Text 	// Is 'true' if the user has already be informed that the Services now again available // Is 'true' if the user has already be informed that the Services now again available
+	MaintenanceMode     bool                  `gorm:"-" json:"maintenance_mode" yaml:"-"`
+	DownText            string                `gorm:"-" json:"-" yaml:"-"` // Contains the current generated Downtime Text 	// Is 'true' if the user has already be informed that the Services now again available // Is 'true' if the user has already be informed that the Services now again available
 	LastStatusCode      int                   `gorm:"-" json:"status_code" yaml:"-"`
 	LastLookupTime      int64                 `gorm:"-" json:"-" yaml:"-"`
 	LastLatency         int64                 `gorm:"-" json:"-" yaml:"-"`


### PR DESCRIPTION
* Adds option when creating announcement to mark service as in maintenance mode.
* Added maintenance mode field to service that is set if any associated messages are active and are set to enable maintenance mode