### PR TITLE
Fix github api version parsing error

### DIFF
--- a/frontend/src/pages/Settings.vue
+++ b/frontend/src/pages/Settings.vue
@@ -177,7 +177,7 @@
             return this.$store.getters.notifiers
           },
         version_below() {
-            if (!this.github || !this.core.version) {
+            if (!this.github?.tag_name || !this.core.version) {
               return false
             }
             return semver.gt(semver.coerce(this.github.tag_name), semver.coerce(this.core.version))


### PR DESCRIPTION
If API limit is hit, github will return a valid
JSON response, so it currently is still attempted
to be parsed.

Update logic to actually check for required version field.